### PR TITLE
Some general fixes and improvements

### DIFF
--- a/packages/roc-package-webpack-dev/src/builder/index.js
+++ b/packages/roc-package-webpack-dev/src/builder/index.js
@@ -14,7 +14,7 @@ import { writeStats } from './utils/stats';
  * @param {rocBuilder} rocBuilder - A rocBuilder to base everything on.
  * @returns {rocBuilder}
  */
-export default ({ previousValue: { buildConfig = {}, builder = require('webpack') }}) => (target) => () => {
+export default ({ previousValue: { buildConfig = {}, builder = require('webpack') } = {} }) => (target) => () => {
     const buildSettings = getSettings('build');
 
     const DEV = (buildSettings.mode === 'dev');
@@ -70,20 +70,24 @@ export default ({ previousValue: { buildConfig = {}, builder = require('webpack'
         loaders: []
     };
 
+    buildConfig.babel = {
+        presets: [
+            require.resolve('babel-preset-es2015'),
+            require.resolve('babel-preset-stage-1')
+        ],
+        plugins: [
+            require.resolve('babel-plugin-transform-runtime'),
+            require.resolve('babel-plugin-transform-decorators-legacy')
+        ]
+    };
+
     // JS LOADER
     const jsLoader = {
+        id: 'babel',
         test: /\.js$/,
         loader: 'babel-loader',
         query: {
-            cacheDirectory: true,
-            presets: [
-                require.resolve('babel-preset-es2015'),
-                require.resolve('babel-preset-stage-1')
-            ],
-            plugins: [
-                require.resolve('babel-plugin-transform-runtime'),
-                require.resolve('babel-plugin-transform-decorators-legacy')
-            ]
+            cacheDirectory: true
         },
         include: runThroughBabel
     };

--- a/packages/roc-package-webpack-dev/src/builder/index.js
+++ b/packages/roc-package-webpack-dev/src/builder/index.js
@@ -57,7 +57,8 @@ export default ({ previousValue: { buildConfig = {}, builder = require('webpack'
     buildConfig.output = {
         path: outputPath,
         filename: '[name].js',
-        chunkFilename: '[name].js'
+        chunkFilename: '[name].js',
+        publicPath: ''
     };
 
     /**

--- a/packages/roc-package-webpack-dev/src/builder/utils/stats.js
+++ b/packages/roc-package-webpack-dev/src/builder/utils/stats.js
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'fs';
 import { extname, join } from 'path';
+import { getSettings } from 'roc';
 
 /**
  * A Webpack plugin that writes stats after a completed build.
@@ -16,8 +17,9 @@ export function writeStats(stats) {
     const analysisFilepath = join(this.options.output.path, 'webpack-analysis.json');
 
     const json = stats.toJson();
+    const name = getSettings('build').name;
 
-    const content = parseStats(json, publicPath);
+    const content = parseStats(json, publicPath, name);
 
     writeFileSync(statsFilepath, JSON.stringify(content));
     writeFileSync(analysisFilepath, JSON.stringify(json));
@@ -31,10 +33,10 @@ export function writeStats(stats) {
  * @returns {object} A object with keys for 'script' and 'css'
  * @private
  */
-export function parseStats(stats, publicPath = '') {
+export function parseStats(stats, publicPath = '', name = 'app') {
     // get chunks by name and extensions
-    const getChunks = (name, ext = 'js') => {
-        let chunk = stats.assetsByChunkName[name];
+    const getChunks = (n, ext = 'js') => {
+        let chunk = stats.assetsByChunkName[n];
 
         // a chunk could be a string or an array, so make sure it is an array
         if (!(Array.isArray(chunk))) {
@@ -46,8 +48,8 @@ export function parseStats(stats, publicPath = '') {
             .map((chunkName) => publicPath + chunkName);
     };
 
-    const script = getChunks('app', 'js');
-    const css = getChunks('app', 'css');
+    const script = getChunks(name, 'js');
+    const css = getChunks(name, 'css');
 
     return {
         script,

--- a/packages/roc-package-webpack-dev/src/roc/index.js
+++ b/packages/roc-package-webpack-dev/src/roc/index.js
@@ -19,7 +19,6 @@ export default {
     ],
     actions: {
         webpack: {
-            extension: name,
             hook: 'build-webpack',
             description: 'Adds base Webpack configuration.',
             action: () => createBuilder


### PR DESCRIPTION
More robust builder that does not require that the hook provides default value.
Moved babel configuration to a "global" one so that can be reused by other loaders, like isparta.
Fixed a small issue in the stats generation after allowing to change the built resource name.
Made sure that the build-webpack action runs always, this makes it possible to call it from other places like when running tests.