### PR TITLE
Moved definition of publicPath to package-webpack

### DIFF
--- a/packages/roc-package-webpack-dev/package.json
+++ b/packages/roc-package-webpack-dev/package.json
@@ -31,6 +31,8 @@
     "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-es2015": "~6.5.0",
     "babel-preset-stage-1": "~6.5.0",
+    "chalk": "~1.1.1",
+    "dev-ip": "~1.0.1",
     "json-loader": "~0.5.3",
     "lodash": "~4.5.1",
     "mkdirp": "~0.5.1",

--- a/packages/roc-package-webpack-dev/src/builder/index.js
+++ b/packages/roc-package-webpack-dev/src/builder/index.js
@@ -6,6 +6,7 @@ import { getValueFromPotentialObject } from 'roc-package-base-dev';
 
 import runThroughBabel from '../helpers/run-through-babel';
 import { writeStats } from './utils/stats';
+import { addTrailingSlash, getDevPath } from '../helpers';
 
 /**
  * Creates a builder.
@@ -58,7 +59,7 @@ export default ({ previousValue: { buildConfig = {}, builder = require('webpack'
         path: outputPath,
         filename: '[name].js',
         chunkFilename: '[name].js',
-        publicPath: ''
+        publicPath: DIST ? addTrailingSlash(buildSettings.path) : getDevPath()
     };
 
     /**

--- a/packages/roc-package-webpack-dev/src/config/roc.config.js
+++ b/packages/roc-package-webpack-dev/src/config/roc.config.js
@@ -7,6 +7,9 @@ const config = {
             mode: 'dist',
             disableProgressbar: false,
             name: 'app'
+        },
+        dev: {
+            port: 3001
         }
     }
 };

--- a/packages/roc-package-webpack-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-dev/src/config/roc.config.meta.js
@@ -2,7 +2,8 @@ import {
     isString,
     isBoolean,
     isPath,
-    isArrayOrSingle
+    isArrayOrSingle,
+    isInteger
 } from 'roc/validators';
 
 const meta = {
@@ -13,6 +14,9 @@ const meta = {
                 mode: 'What mode the application should be built for. Possible values are "dev" and "dist".',
                 disableProgressbar: 'Should the progress bar be disabled for builds.',
                 name: 'The name of the generated application bundle.'
+            },
+            dev: {
+                port: 'Port for the dev server.'
             }
         },
 
@@ -24,6 +28,9 @@ const meta = {
                 input: isArrayOrSingle(isPath),
                 output: isArrayOrSingle(isPath),
                 name: isArrayOrSingle(isString)
+            },
+            dev: {
+                port: isInteger
             }
         }
     },

--- a/packages/roc-package-webpack-dev/src/helpers/index.js
+++ b/packages/roc-package-webpack-dev/src/helpers/index.js
@@ -1,0 +1,85 @@
+import devip from 'dev-ip';
+import chalk from 'chalk';
+
+import { getSettings } from 'roc';
+
+import config from '../config/roc.config.js';
+
+let onceDevPort = true;
+
+/**
+ * Returns the current dev path.
+ *
+ * Will use {@link getDevPort} for getting the port.
+ *
+ * @param {string} [relativeBuildPath] - Relative path to where the build is saved.
+ * @returns {string} The complete dev path on the server including the port.
+ */
+export function getDevPath(relativeBuildPath = '') {
+    const devIp = devip().length > 0 ? devip()[0] : 'localhost';
+    const buildPath = relativeBuildPath && relativeBuildPath.slice(-1) !== '/' ?
+        relativeBuildPath + '/' :
+        relativeBuildPath;
+
+    return `http://${devIp}:${getDevPort()}/${buildPath}`;
+}
+
+/**
+ * Returns the current dev port.
+ *
+ *It will first default to the environment variable `DEV_PORT` and after that `roc.config.js`.
+ *
+ * Will give a warning if `DEV_PORT` is defined and the value in the configuration is something other than default.
+ *
+ * @returns {number} The final port for the dev server.
+ */
+export function getDevPort() {
+    const settings = getSettings('dev');
+
+    if (settings.port !== config.settings.dev.port && process.env.DEV_PORT && onceDevPort) {
+        onceDevPort = false;
+        /* eslint-disable no-console */
+        console.log(chalk.red('You have configured a dev port but the environment ' +
+            'variable DEV_PORT is set and that will be used instead. The port that will be used is ' +
+            process.env.DEV_PORT
+        ));
+        /* eslint-enable */
+    }
+    return process.env.DEV_PORT || settings.port;
+}
+
+/**
+* Removes possible trailing slashes from a path.
+*
+* @param {string} path - Path to remove possible trailing slashes.
+*
+* @returns {string} - Path without trailing slashes.
+*/
+export function removeTrailingSlash(path) {
+    const newPath = path.replace(/\/+$/, '');
+
+    if (!newPath) {
+        return '/';
+    }
+
+    return newPath;
+}
+
+/**
+* Adds a trailing slashes to a path.
+*
+* Runs {@link removeTrailingSlash} internally first.
+*
+* @param {string} path - Path to add a trailing slashes to.
+*
+* @returns {string} - Path with trailing slash.
+*/
+export function addTrailingSlash(path) {
+    const newPath = removeTrailingSlash(path);
+
+    if (newPath !== '/') {
+        return newPath + '/';
+    }
+
+    return newPath;
+}

--- a/packages/roc-package-webpack-dev/src/index.js
+++ b/packages/roc-package-webpack-dev/src/index.js
@@ -3,3 +3,10 @@ export roc from './roc';
 export createBuilder from './builder';
 
 export { parseStats } from './builder/utils/stats';
+
+export {
+    getDevPath,
+    getDevPort,
+    removeTrailingSlash,
+    addTrailingSlash
+} from './helpers';


### PR DESCRIPTION
This makes sure that the server also have access to this, making sure that universal applications work as they should.
A better pattern to do this should probably be done in the future since this create a strong coupling between the packages.