### PR TITLE
Changed so that babel-config is triggered outside of build-webpack

### DIFF
--- a/extensions/roc-package-webpack-dev/src/actions/build.js
+++ b/extensions/roc-package-webpack-dev/src/actions/build.js
@@ -114,7 +114,8 @@ export default ({ context: { verbose, config: { settings } } }) => (targets) => 
     log.small.log(`Starting the builder using "${settings.build.mode}" as the mode.\n`);
 
     const promises = validTargets.map((target) => {
-        const webpackConfig = invokeHook('build-webpack', target);
+        const babelConfig = invokeHook('babel-config', target);
+        const webpackConfig = invokeHook('build-webpack', target, babelConfig);
         return build(webpackConfig, target, settings, verbose);
     });
 

--- a/extensions/roc-package-webpack-dev/src/actions/dev.js
+++ b/extensions/roc-package-webpack-dev/src/actions/dev.js
@@ -85,7 +85,8 @@ export default ({ context: { verbose, config: { settings } } }) => (targets) => 
 
     // Build each one in order
     return Promise.all(targets.map(async function builders(target) {
-        const webpackConfig = invokeHook('build-webpack', target);
+        const babelConfig = invokeHook('babel-config', target);
+        const webpackConfig = invokeHook('build-webpack', target, babelConfig);
         return await createWatcher(verbose, newSettings, target, webpackConfig, watchers);
     }));
 };

--- a/extensions/roc-package-webpack-dev/src/roc/index.js
+++ b/extensions/roc-package-webpack-dev/src/roc/index.js
@@ -4,7 +4,7 @@ import { isString, isObject, isFunction, isArray } from 'roc/validators';
 import config from '../config/roc.config.js';
 import meta from '../config/roc.config.meta.js';
 
-import { name } from './util';
+import { invokeHook } from './util';
 
 const lazyRequire = lazyFunctionRequire(require);
 
@@ -23,16 +23,18 @@ export default {
     },
     actions: [{
         hook: 'babel-config',
-        extension: name,
-        action: () => () => (babelConfig) => {
-            babelConfig.presets.push(
-                require.resolve('babel-preset-es2015'),
-                require.resolve('babel-preset-stage-1')
-            );
-            babelConfig.plugins.push(
-                require.resolve('babel-plugin-transform-runtime'),
-                require.resolve('babel-plugin-transform-decorators-legacy')
-            );
+        action: () => (target) => (babelConfig) => {
+            const targets = invokeHook('get-webpack-targets');
+            if (targets.indexOf(target) !== -1) {
+                babelConfig.presets.push(
+                    require.resolve('babel-preset-es2015'),
+                    require.resolve('babel-preset-stage-1')
+                );
+                babelConfig.plugins.push(
+                    require.resolve('babel-plugin-transform-runtime'),
+                    require.resolve('babel-plugin-transform-decorators-legacy')
+                );
+            }
 
             return babelConfig;
         },
@@ -59,6 +61,10 @@ export default {
                 target: {
                     validator: isString,
                     description: 'The target for which the Webpack configuration should be build for.',
+                },
+                babelConfig: {
+                    validator: isObject(),
+                    description: 'The Babel configuration that should be used for the Webpack build.',
                 },
             },
         },

--- a/extensions/roc-package-webpack-dev/src/webpack/index.js
+++ b/extensions/roc-package-webpack-dev/src/webpack/index.js
@@ -7,7 +7,7 @@ import webpack from 'webpack';
 
 import runThroughBabel from '../helpers/runThroughBabel';
 import { addTrailingSlash, getDevPath } from '../helpers';
-import { name, version, invokeHook } from '../roc/util';
+import { name, version } from '../roc/util';
 
 import { writeStats } from './utils/stats';
 import RocExportPlugin from './utils/rocExportWebpackPlugin';
@@ -21,7 +21,7 @@ const log = initLog(name, version);
  * @param {rocBuilder} rocBuilder - A rocBuilder to base everything on.
  * @returns {rocBuilder}
  */
-export default ({ previousValue: webpackConfig = {} }) => (target) => () => {
+export default () => (target, babelConfig) => (webpackConfig = {}) => {
     const newWebpackConfig = { ...webpackConfig };
     const buildSettings = getSettings('build');
 
@@ -89,7 +89,7 @@ export default ({ previousValue: webpackConfig = {} }) => (target) => () => {
         test: /\.js$/,
         loader: require.resolve('babel-loader'),
         query: {
-            ...invokeHook('babel-config', target),
+            ...babelConfig,
             cacheDirectory: true,
         },
         include: runThroughBabel,


### PR DESCRIPTION
This allows for greater flexibility and is needed for great documentation generation when using together with tests.