### PR TITLE
Use process.env.NODE_ENV in the webpack build

### DIFF
--- a/extensions/roc-package-webpack-dev/src/webpack/index.js
+++ b/extensions/roc-package-webpack-dev/src/webpack/index.js
@@ -28,11 +28,15 @@ export default () => (target, babelConfig) => (webpackConfig = {}) => {
     const DEV = (buildSettings.mode === 'dev');
     const DIST = (buildSettings.mode === 'dist');
 
-    let ENV = buildSettings.mode;
-    if (DIST) {
-        ENV = 'production';
-    } else if (DEV) {
-        ENV = 'development';
+    // Use process.env.NODE_ENV as ENV and fallback to use the mode if not defined
+    let ENV = process.env.NODE_ENV;
+    if (!ENV) {
+        ENV = buildSettings.mode;
+        if (DIST) {
+            ENV = 'production';
+        } else if (DEV) {
+            ENV = 'development';
+        }
     }
 
     const entry = getAbsolutePath(getValueFromPotentialObject(buildSettings.input, target));


### PR DESCRIPTION
This change makes it possible to change the process.env.NODE_ENV inside the code that is built with webpack in a more natural way.

This change is connected with https://github.com/rocjs/roc-abstract-package-base/pull/16. 

This means that when running `roc build` we will by default use `NODE_ENV=production` even if we have selected another `mode` in Roc. The same goes for `roc-abstract-plugin-test` that enforces `NODE_ENV=test`.

This might be a little confusing and we should consider if we need `mode` and maybe use `NODE_ENV` instead generally. 