### PR TITLE
Support scopes in Babel loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ before_install:
   - npm install -g npm
 before_script:
   - npm run link
+  - npm run build
 after_success:
   - npm start build && npm start docs

--- a/extensions/roc-package-webpack-dev/src/helpers/runThroughBabel.js
+++ b/extensions/roc-package-webpack-dev/src/helpers/runThroughBabel.js
@@ -1,9 +1,8 @@
-// const regexp = /(node_modules)\/(roc-[^/]*)?\/?([^/]*)/g;
 import { sep } from 'path';
 
 import createPathRegExp from 'roc/lib/require/createPathRegExp';
 
-const regexp = createPathRegExp(`(node_modules)${sep}(roc-[^${sep}]*)?${sep}?([^${sep}]*)`, 'g');
+const regexp = createPathRegExp(`roc-[^${sep}]+${sep}(?:app$|app${sep})`);
 
 export default function runThroughBabel(absPath) {
     /* This function will look at the absolute path for the current file
@@ -12,19 +11,9 @@ export default function runThroughBabel(absPath) {
      * What this does exactly is that it finds the last match of "roc-X/SOMETHING".
      * If SOMETHING is "app" it will include it and process it with babel.
      */
-    let match;
-    const matches = [];
-
-    // eslint-disable-next-line
-    while ((match = regexp.exec(absPath))) {
-        matches.push({ nodeModules: match[1], roc: match[2], next: match[3] });
-    }
-
-    const last = matches[matches.length - 1];
-    if (last && last.nodeModules === 'node_modules' && (!last.roc || last.next !== 'app')) {
-        // We do not want to process this with babel-loader.
-        // We explicitly set here that roc-X/app should be run through Babel
-        // Would like to avoid this, see issue https://github.com/webpack/webpack/issues/1071
+    if (regexp.test(absPath)) {
+        return true;
+    } else if (/node_modules/.test(absPath)) {
         return false;
     }
 

--- a/extensions/roc-package-webpack-dev/test/index.js
+++ b/extensions/roc-package-webpack-dev/test/index.js
@@ -1,10 +1,6 @@
-/*
- Currently not in use, will be re-enabled at a later time.
-*/
+const assert = require('assert');
 
-import expect from 'expect';
-
-import runThroughBabel from '../src/helpers/run-through-babel';
+const runThroughBabel = require('../lib/helpers/runThroughBabel').default;
 
 const shouldBeFalse = [
     '/public/roc-package/roc-package-webpack/dev/node_modules/webpack-hot-middleware/client-overlay.js',
@@ -17,24 +13,14 @@ const shouldBeTrue = [
     '/public/roc-app/app/client-overlay.js',
     '/public/myApp/app/client-overlay.js',
     '/public/myApp/client-overlay.js',
+    '/public/roc-app/node_modules/@spp/roc-package-demo/app/code.js',
 ];
 
-describe('roc-package-webpack-dev', () => {
-    describe('runThroughBabel', () => {
-        describe('should correctly handle path and return false', () => {
-            shouldBeFalse.forEach((path) => {
-                it(path, () => {
-                    expect(runThroughBabel(path)).toBe(false);
-                });
-            });
-        });
 
-        describe('should correctly handle path and return true', () => {
-            shouldBeTrue.forEach((path) => {
-                it(path, () => {
-                    expect(runThroughBabel(path)).toBe(true);
-                });
-            });
-        });
-    });
+shouldBeFalse.forEach((path) => {
+    assert(runThroughBabel(path) === false, path);
+});
+
+shouldBeTrue.forEach((path) => {
+    assert(runThroughBabel(path) === true, path);
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "rid lint:alias",
     "link": "rid link",
     "link:all": "rid link roc,roc-abstract-package-base-dev,roc-abstract-package-base",
-    "test": "npm run lint"
+    "test": "npm run lint && node extensions/roc-package-webpack-dev/test/index.js"
   },
   "devDependencies": {
     "@rocjs/roc-internal-dev": "^2.0.0",


### PR DESCRIPTION
Supporting scopes in logic for when Babel should be applied. This was an error and should have been supported already.

Also made the logic smarter at the same time and enabled tests.