### PR TITLE
Use the new async resolver from roc and change how resolving is done

### DIFF
--- a/extensions/roc-package-webpack-dev/src/roc/index.js
+++ b/extensions/roc-package-webpack-dev/src/roc/index.js
@@ -9,6 +9,7 @@ import { invokeHook } from './util';
 const lazyRequire = lazyFunctionRequire(require);
 
 export default {
+    required: { roc: '^1.0.0-rc.18' },
     description: 'Package providing module support.',
     config,
     meta,

--- a/extensions/roc-package-webpack-dev/src/webpack/index.js
+++ b/extensions/roc-package-webpack-dev/src/webpack/index.js
@@ -125,7 +125,7 @@ export default () => (target, babelConfig) => (webpackConfig = {}) => {
     newWebpackConfig.plugins = [];
 
     newWebpackConfig.plugins.push(
-        new RocExportPlugin(getResolveRequest('Webpack')),
+        new RocExportPlugin(getResolveRequest('Webpack', true)),
 
         // process.env.NODE_ENV is used by React and some other libs to determine what to run
         new webpack.DefinePlugin({


### PR DESCRIPTION
- Resolving is now more reliable.
- Resolving is now always async, matching how Webpack works internally.
- Solves a bug where dependencies that used special fields in `package.json` would be imported incorrectly.

Dependent on https://github.com/rocjs/roc/pull/165 to be merged and released as at least `1.0.0-rc.18`.